### PR TITLE
IGNITE-16078: Fix RPM placement during deploy

### DIFF
--- a/scripts/release_2[bintray]upload_packages.sh
+++ b/scripts/release_2[bintray]upload_packages.sh
@@ -104,7 +104,7 @@ for rpm in *.rpm; do
     repository="ignite-rpm"
 
     checkPackageExistence "${repository}" "${package_name}" "${description}"
-    response=$(curl -H "X-JFrog-Art-Api:${AUTH}" -X PUT https://apache.jfrog.io/artifactory/ignite-rpm/"${package_name}"/"${ignite_version}"/"${rpm}" -T "${rpm}")
+    response=$(curl -H "X-JFrog-Art-Api:${AUTH}" -X PUT https://apache.jfrog.io/artifactory/ignite-rpm/"${rpm}" -T "${rpm}")
 
     echo "$response"
 done


### PR DESCRIPTION
Artifactory expects that RPM will be placed in directory next to repodata directory in order to automatically regenerate index of repository. It ignores `"${package_name}"/"${ignite_version}"/"${rpm}"` location, expecting just "${rpm}".